### PR TITLE
fix find_if not found

### DIFF
--- a/source/lib/utility/include/DebugController.h
+++ b/source/lib/utility/include/DebugController.h
@@ -4,6 +4,7 @@
 
 #include "lib/utility/include/Utility.h"
 
+#include <algorithm>
 #include <string>
 #include <any>
 #include <map>


### PR DESCRIPTION
```
error: 'find_if' is not a member of 'std';
```