### PR TITLE
Upgrade package management to conan 2

### DIFF
--- a/.github/workflows/x86_64-macos14-clang15.yml
+++ b/.github/workflows/x86_64-macos14-clang15.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '23 3 2,12,22 * *'
 
+env:
+  CONAN_USER_HOME: ${{ github.workspace }}/conan
+
 jobs:
   build:
     runs-on: [self-hosted, macOS, X64]
@@ -16,14 +19,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install build environment
+        run: |
+          python3 -m venv .venv && . .venv/bin/activate && pip install "conan" "numpy<2.0"
+
+      - name: Setup conan
+        run: . .venv/bin/activate && etc/conan-config.sh gcc $GCC_VERSION
+
+
       - name: Cache/Restore dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.conan/data
+          path: ./conan
           key: ${{ runner.os }}-${{ github.workflow }}-conanfile-${{ hashFiles('conanfile.py') }}
 
       - name: Install dependencies
-        run: etc/conan-install.sh Release
+        run: . .venv/bin/activate && etc/conan-install.sh Release
 
       - name: Build
         run: |

--- a/.github/workflows/x86_64-ubuntu22-clang14.yml
+++ b/.github/workflows/x86_64-ubuntu22-clang14.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Install conan
         uses: turtlebrowser/get-conan@main
-        with:
-          version: 1.65.0
 
       - name: Setup conan
         run: etc/conan-config.sh clang $CLANG_VERSION

--- a/.github/workflows/x86_64-ubuntu22-gcc11.yml
+++ b/.github/workflows/x86_64-ubuntu22-gcc11.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Install conan
         uses: turtlebrowser/get-conan@main
-        with:
-          version: 1.65.0
 
       - name: Setup conan
         run: etc/conan-config.sh gcc $GCC_VERSION

--- a/.github/workflows/x86_64-ubuntu24-gcc13.yml
+++ b/.github/workflows/x86_64-ubuntu24-gcc13.yml
@@ -33,7 +33,7 @@ jobs:
           #
           # numpy is required to get boost.python compiled via conan recipe
           #
-          python3 -m venv .venv && . .venv/bin/activate && pip install "conan<2.0" "numpy<2.0"
+          python3 -m venv .venv && . .venv/bin/activate && pip install "conan" "numpy<2.0"
 
       - name: Setup conan
         run: . .venv/bin/activate && etc/conan-config.sh gcc $GCC_VERSION

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ is required to have python3-dev installed. In Ubuntu, the following steps should
 ```
 apt-get install --no-install-recommends -y build-essential cmake python3-pip python3-dev python-is-python3
 
-pip3 install "conan<2.0" "numpy<2.0"
+pip3 install "conan" "numpy<2.0"
 conan profile new ticket-decoder --force --detect
 conan profile update settings.compiler.libcxx=libstdc++11 ticket-decoder
 
@@ -269,7 +269,7 @@ the step "Install compiler and stdlib" in ".github/workflows/c-cpp.yml" for a li
 ```
 apt-get install --no-install-recommends -y build-essential make cmake git wget python-is-python3 python3-pip python3-dev libgtk2.0-dev
 
-pip3 install "conan<2.0" "numpy<2.0"
+pip3 install "conan" "numpy<2.0"
 conan profile new --detect --force ticket-decoder
 conan profile update settings.compiler.libcxx=libstdc++11 ticket-decoder
 conan profile update conf.tools.system.package_manager:mode=install ticket-decoder
@@ -295,7 +295,7 @@ is no package python-is-python3 in homebrew available, as it is for ubuntu.
 xcode-select --install
 
 brew install cmake
-pip3 install "conan<2.0" "numpy<2.0"
+pip3 install "conan" "numpy<2.0"
 conan profile new --detect --force ticket-decoder
 conan profile update settings.compiler.version=15.0 ticket-decoder
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conan import ConanFile, tools
 from conan.tools.cmake import CMake, cmake_layout
 
 class TicketDecoderConan(ConanFile):
@@ -9,115 +9,115 @@ class TicketDecoderConan(ConanFile):
    options = {
                "with_analyzer": [True, False]
              }
-   requires = [
-               # https://conan.io/center/recipes/opencv
-               ("opencv/4.10.0"),
-               # https://conan.io/center/recipes/zxing-cpp
-               ("zxing-cpp/2.2.1"),
-               # https://conan.io/center/recipes/nlohmann_json
-               ("nlohmann_json/3.11.3"),
-               # https://conan.io/center/recipes/easyloggingpp
-               ("easyloggingpp/9.97.1"),
-               # https://conan.io/center/recipes/pugixml
-               ("pugixml/1.14"),
-               # https://conan.io/center/recipes/botan
-               ("botan/2.19.5"),
-               # https://conan.io/center/recipes/tclap
-               ("tclap/1.2.5"),
-               # https://conan.io/center/recipes/boost
-               ("boost/1.86.0"),
-               # Override some requirements for poppler, since it uses older dependencies than opencv for same libs
-               # ("zlib/1.3", "override"),        # Remove this direct override when poppler gets updated
-               # ("libpng/1.6.42", "override"),   # Remove this direct override when freetype/2.12.1 vs. opencv/4.8.1 gets updated
-               # ("expat/2.6.0", "override"),     # Remove this direct override when fontconfig/2.13.93 vs. wayland/1.22.0 gets updated
-               ("fontconfig/2.15.0", "override"),
-               # https://conan.io/center/recipes/poppler
-               ("poppler/21.07.0"),
-               # https://conan.io/center/recipes/gtest
-               ("gtest/1.15.0"),
-               ]
    default_options = {
                 # global
                 "*:shared": False,
                 # ticket-decoder
                 "with_analyzer": True,
                 # opencv
-                "opencv:highgui": True,
-                "opencv:parallel": False,
-                "opencv:stitching": False,
-                "opencv:video": False, # Disables video processing only, required video-io keeps enabled
-                "opencv:with_ffmpeg": False,
-                "opencv:with_jpeg2000": False,
-                "opencv:with_tiff": False,
-                "opencv:with_webp": False,
-                "opencv:with_quirc": False,
-                "opencv:with_openexr": False,
-                "opencv:with_eigen": False,
-                "opencv:with_tesseract": False,
-                "opencv:with_protobuf": False,
-                "opencv:gapi": False,
-                "opencv:ml": False,
-                "opencv:dnn": False,
-                "opencv:calib3d": True, # Required by objdetect
-                "opencv:photo": False,
-                "opencv:stitching": False,
+                "opencv/*:highgui": True,
+                "opencv/*:parallel": False,
+                "opencv/*:stitching": False,
+                "opencv/*:video": False, # Disables video processing only, required video-io keeps enabled
+                "opencv/*:with_ffmpeg": False,
+                "opencv/*:with_jpeg2000": False,
+                "opencv/*:with_tiff": False,
+                "opencv/*:with_webp": False,
+                "opencv/*:with_quirc": False,
+                "opencv/*:with_openexr": False,
+                "opencv/*:with_eigen": False,
+                "opencv/*:with_tesseract": False,
+                "opencv/*:with_protobuf": False,
+                "opencv/*:gapi": False,
+                "opencv/*:ml": False,
+                "opencv/*:dnn": False,
+                "opencv/*:calib3d": True, # Required by objdetect
+                "opencv/*:photo": False,
+                "opencv/*:stitching": False,
                 # zxing-cpp
-                "zxing-cpp:enable_encoders": False,
+                "zxing-cpp/*:enable_encoders": False,
                 # easyloggingpp
-                "easyloggingpp:enable_default_logfile": False,
+                "easyloggingpp/*:enable_default_logfile": False,
                 # botan
                 # "botan:with_bzip2": True,
                 # "botan:with_zlib": True,
                 # boost
-                "boost:pch": False,
-                "boost:header_only": False,
-                "boost:without_atomic": True,
-                "boost:without_charconv": True,
-                "boost:without_chrono": True,
-                "boost:without_cobalt": True,
-                "boost:without_container": True,
-                "boost:without_context": True,
-                "boost:without_contract": True,
-                "boost:without_coroutine": True,
-                "boost:without_date_time": True,
-                "boost:without_exception": True,
-                "boost:without_fiber": True,
-                "boost:without_filesystem": True,
-                "boost:without_graph": True,
-                "boost:without_graph_parallel": True,
-                "boost:without_iostreams": True,
-                "boost:without_json": True,
-                "boost:without_locale": True,
-                "boost:without_log": True,
-                "boost:without_math": True,
-                "boost:without_mpi": True,
-                "boost:without_nowide": True,
-                "boost:without_process": True,
-                "boost:without_program_options": True,
-                "boost:without_python": False,          # <-- that's what you are looking for
-                "boost:without_random": True,
-                "boost:without_regex": True,
-                "boost:without_serialization": True,
-                "boost:without_stacktrace": True,
-                "boost:without_system": True,
-                "boost:without_test": True,
-                "boost:without_thread": True,
-                "boost:without_timer": True,
-                "boost:without_type_erasure": True,
-                "boost:without_url": True,
-                "boost:without_wave": True,
+                "boost/*:pch": False,
+                "boost/*:header_only": False,
+                "boost/*:without_atomic": True,
+                "boost/*:without_charconv": True,
+                "boost/*:without_chrono": True,
+                "boost/*:without_cobalt": True,
+                "boost/*:without_container": True,
+                "boost/*:without_context": True,
+                "boost/*:without_contract": True,
+                "boost/*:without_coroutine": True,
+                "boost/*:without_date_time": True,
+                "boost/*:without_exception": True,
+                "boost/*:without_fiber": True,
+                "boost/*:without_filesystem": True,
+                "boost/*:without_graph": True,
+                "boost/*:without_graph_parallel": True,
+                "boost/*:without_iostreams": True,
+                "boost/*:without_json": True,
+                "boost/*:without_locale": True,
+                "boost/*:without_log": True,
+                "boost/*:without_math": True,
+                "boost/*:without_mpi": True,
+                "boost/*:without_nowide": True,
+                "boost/*:without_process": True,
+                "boost/*:without_program_options": True,
+                "boost/*:without_python": False,          # <-- that's what you are looking for
+                "boost/*:without_random": True,
+                "boost/*:without_regex": True,
+                "boost/*:without_serialization": True,
+                "boost/*:without_stacktrace": True,
+                "boost/*:without_system": True,
+                "boost/*:without_test": True,
+                "boost/*:without_thread": True,
+                "boost/*:without_timer": True,
+                "boost/*:without_type_erasure": True,
+                "boost/*:without_url": True,
+                "boost/*:without_wave": True,
                 # poppler
-                "poppler:fontconfiguration": "fontconfig",
-                "poppler:with_lcms": False,
-                "poppler:with_libcurl": False,
-                "poppler:with_nss": False,
-                "poppler:with_libjpeg": False,
-                "poppler:with_openjpeg": False,
-                "poppler:with_png": False,
-                "poppler:with_qt": False,
-                "poppler:with_tiff": False,
-                "poppler:with_zlib": False
+                "poppler/*:fontconfiguration": "fontconfig",
+                "poppler/*:with_lcms": False,
+                "poppler/*:with_libcurl": False,
+                "poppler/*:with_nss": False,
+                "poppler/*:with_libjpeg": False,
+                "poppler/*:with_openjpeg": False,
+                "poppler/*:with_png": False,
+                "poppler/*:with_qt": False,
+                "poppler/*:with_tiff": False,
+                "poppler/*:with_zlib": False
                 }
+
+   def requirements(self):
+      # https://conan.io/center/recipes/opencv
+      self.requires("opencv/4.10.0")
+      # https://conan.io/center/recipes/zxing-cpp
+      self.requires("zxing-cpp/2.2.1")
+      # https://conan.io/center/recipes/nlohmann_json
+      self.requires("nlohmann_json/3.11.3")
+      # https://conan.io/center/recipes/easyloggingpp
+      self.requires("easyloggingpp/9.97.1")
+      # https://conan.io/center/recipes/pugixml
+      self.requires("pugixml/1.14")
+      # https://conan.io/center/recipes/botan
+      self.requires("botan/2.19.5")
+      # https://conan.io/center/recipes/tclap
+      self.requires("tclap/1.2.5")
+      # https://conan.io/center/recipes/boost
+      self.requires("boost/1.86.0")
+      # Override some requirements for poppler, since it uses older dependencies than opencv for same libs
+      # ("zlib/1.3", "override"),        # Remove this direct override when poppler gets updated
+      # ("libpng/1.6.42", "override"),   # Remove this direct override when freetype/2.12.1 vs. opencv/4.8.1 gets updated
+      # ("expat/2.6.0", "override"),     # Remove this direct override when fontconfig/2.13.93 vs. wayland/1.22.0 gets updated
+      self.requires("fontconfig/2.15.0", override=True)
+      # https://conan.io/center/recipes/poppler
+      self.requires("poppler/25.01.0")
+      # https://conan.io/center/recipes/gtest
+      self.test_requires("gtest/1.15.0")
 
    def configure(self):
       if self.options.with_analyzer == False:

--- a/etc/conan-config.sh
+++ b/etc/conan-config.sh
@@ -6,24 +6,14 @@ readonly WORKSPACE_ROOT="$(readlink -f $(dirname "$0"))"/../
 COMPILER_NAME=${1}
 COMPILER_VERSION=${2}
 
-conan profile new ticket-decoder --force --detect
+conan profile detect --name ticket-decoder --force
 
-if [[ -z "${COMPILER_NAME}" ]]; then
-    COMPILER_NAME=$(conan profile get settings.compiler ticket-decoder)
-    if [[ -z "${COMPILER_NAME}" ]]; then
-        echo "ERROR: No compiler auto-dectected or passed as argument"
-        exit 1
-    fi
-else
-    conan profile update settings.compiler=${COMPILER_NAME} ticket-decoder
-fi
+#if [[ ! -z "${COMPILER_NAME}" ]]; then
+#    conan profile show -pr ticket-decoder -s compiler=${COMPILER_NAME}
+#fi
 
-if [[ ! -z ${COMPILER_VERSION} ]]; then
-    conan profile update settings.compiler.version=${COMPILER_VERSION} ticket-decoder
-fi
+#if [[ ! -z ${COMPILER_VERSION} ]]; then
+#    conan profile show -pr ticket-decoder -s compiler.version=${COMPILER_VERSION}
+#fi
 
-readonly STANDARD_LIB=$(if [[ "$COMPILER_NAME" =~ ^(clang|apple-clang)$ ]]; then echo 'libc++'; else echo 'libstdc++11'; fi)
-conan profile update settings.compiler.libcxx=${STANDARD_LIB} ticket-decoder
-
-conan profile update conf.tools.system.package_manager:mode=install ticket-decoder
-conan profile show ticket-decoder
+#conan profile show -pr ticket-decoder -c tools.system.package_manager:mode=install

--- a/etc/conan-install.sh
+++ b/etc/conan-install.sh
@@ -6,10 +6,10 @@ readonly WORKSPACE_ROOT="$(readlink -f $(dirname "$0"))"/../
 readonly BUILD_TYPE=${1:-Release}
 
 conan install ${WORKSPACE_ROOT} \
-    -if ${WORKSPACE_ROOT}/build/${BUILD_TYPE} \
+    -of ${WORKSPACE_ROOT}/build/${BUILD_TYPE} \
     -pr ticket-decoder -pr:b ticket-decoder \
     -s build_type=${BUILD_TYPE} \
     --build missing \
     ${@:2}
 
-conan remove '*' --build --src --force
+conan cache clean '*'

--- a/etc/docker/ubuntu22.clang.Dockerfile
+++ b/etc/docker/ubuntu22.clang.Dockerfile
@@ -24,7 +24,7 @@ RUN update-alternatives --install /usr/bin/ld      ld      /usr/bin/ld.lld-$CLAN
 WORKDIR /ticket-decoder
 COPY etc/conan-config.sh etc/conan-install.sh etc/cmake-config.sh etc/cmake-build.sh etc/python-test.sh etc/install-uic-keys.sh etc/
 
-RUN pip install "conan<2.0" "numpy<2.0" jsonpath2
+RUN pip install "conan" "numpy<2.0" jsonpath2
 RUN etc/conan-config.sh clang $CLANG_VERSION
 
 COPY conanfile.py .

--- a/etc/docker/ubuntu22.gcc.Dockerfile
+++ b/etc/docker/ubuntu22.gcc.Dockerfile
@@ -20,7 +20,7 @@ RUN update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-$GCC_VERSION 800
 WORKDIR /ticket-decoder
 COPY etc/conan-config.sh etc/conan-install.sh etc/cmake-config.sh etc/cmake-build.sh etc/python-test.sh etc/install-uic-keys.sh etc/
 
-RUN pip install "conan<2.0" "numpy<2.0" jsonpath2
+RUN pip install "conan" "numpy<2.0" jsonpath2
 RUN etc/conan-config.sh gcc $GCC_VERSION
 
 COPY conanfile.py .

--- a/etc/docker/ubuntu22.gcc.Python.Dockerfile
+++ b/etc/docker/ubuntu22.gcc.Python.Dockerfile
@@ -20,7 +20,7 @@ RUN update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-$GCC_VERSION 800
 WORKDIR /ticket-decoder
 COPY etc/conan-config.sh etc/conan-install.sh etc/cmake-config.sh etc/cmake-build.sh etc/python-test.sh etc/install-uic-keys.sh etc/
 
-RUN pip install "conan<2.0" "numpy<2.0" jsonpath2
+RUN pip install "conan" "numpy<2.0" jsonpath2
 RUN etc/conan-config.sh gcc $GCC_VERSION
 
 COPY conanfile.py .

--- a/etc/docker/ubuntu24.gcc.Dockerfile
+++ b/etc/docker/ubuntu24.gcc.Dockerfile
@@ -23,7 +23,7 @@ COPY etc/conan-config.sh etc/conan-install.sh etc/cmake-config.sh etc/cmake-buil
 RUN python3 -m venv .venv && \
     . .venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install "conan<2.0" "numpy<2.0" jsonpath2
+    pip install "conan" "numpy<2.0" jsonpath2
 ENV PATH="/ticket-decoder/.venv/bin:$PATH"
 
 RUN etc/conan-config.sh gcc $GCC_VERSION


### PR DESCRIPTION
almost all dependencies are migrated to conan 2 already. the only remaining one is poppler, but there is a pr for this.

this pr has to be merged to get doppler via conan 2 as well: [https://github.com/conan-io/conan-center-index/pull/21135](https://github.com/conan-io/conan-center-index/pull/21135)
